### PR TITLE
Fix: Update start script and make dev start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,13 +30,13 @@
         ]
     },
     "scripts": {
-        "start": "parcel public/index.html",
+        "start": "serve -s dist",
+        "dev start": "parcel public/index.html",
         "format": "npx prettier --write .",
         "build": "parcel build public/index.html",
         "lint": "eslint --fix --ignore-path .gitignore .",
         "test": "jest --ci --reporters=default --coverage",
         "check": "tsc --noEmit",
-        "serve": "serve -s dist",
         "ci": "npm run format && npm run lint && npm run build && npm run test"
     },
     "author": "",


### PR DESCRIPTION
This is so that Heroku may serve our application from our minified "dist" build folder instead of running a development server.